### PR TITLE
add public initializer for KeychainStorage.Domain

### DIFF
--- a/Sources/KeyValueStorage/Storages/KeychainStorage.swift
+++ b/Sources/KeyValueStorage/Storages/KeychainStorage.swift
@@ -106,6 +106,11 @@ public extension KeychainStorage {
     struct Domain: KeyValueDataStorageDomain {
         public let groupId: String
         public let teamId: String
+
+        public init(groupId: String, teamId: String) {
+            self.groupId = groupId
+            self.teamId = teamId
+        }
         
         public var accessGroup: String {
             teamId + "." + groupId


### PR DESCRIPTION
Hi, thanks for this excellent library!

I found that the example usage of creating a `KeychainKey` with a domain fails to compile with the error `'KeychainStorage.Domain' initializer is inaccessible due to 'internal' protection level`, so this just adds a public `init` to that type.